### PR TITLE
クラスモジュールのバグを修正：一度しか代入時型チェックが判定されない

### DIFF
--- a/Assets/cytanb-utility-scripts/lua/kagerou_foundation.lua
+++ b/Assets/cytanb-utility-scripts/lua/kagerou_foundation.lua
@@ -10,25 +10,36 @@ function _defineClass(...) -- @param protocol
     local protocols = {...}
     for _, protocol in pairs(protocols) do
         _tableCopy(protocol, cls)
-        local meta = getmetatable(protocol) or {}
+        local meta = _tableCopy(getmetatable(protocol) or {},{})
         meta.__newindex = nil
         _addmetatable(cls, meta)
     end
-    local _ = DEBUG and DEBUG.setPreNewIndex(cls)
+
     cls._rawnew =
         function(cls)
             local ins = {_ = {}}
             local meta = _tableCopy(getmetatable(cls) or {},{})
-            meta.__index = cls
             local wins = _weak(ins)
             meta.__gc = function(self)
                 wins().delete(self)
             end
             meta._super = cls
+            meta._memberTable = {}
+            meta.__index = function(table,key)
+                local value = rawget(_getMemberTable(wins()),key)
+                if value == nil then
+                    return cls[key]
+                else
+                    return value
+                end
+            end
+            meta.__newindex = function(table,key,value)
+                rawset(_getMemberTable(wins()),key,value)
+            end
             if DEBUG then meta.__newindex = DEBUG.checkSubstitutionFunc() end
             setmetatable(ins, meta)
-            setmetatable(ins._, {__index = function(table,key) return rawget(wins(),key) end,
-                __newindex=function(table,key,value) rawset(wins(),key,value) end})
+            setmetatable(ins._, {__index = function(table,key) return rawget(_getMemberTable(wins()),key) end,
+                __newindex=function(table,key,value) rawset(_getMemberTable(wins()),key,value) end})
             return ins
         end
     local wcls = _weak(cls)
@@ -38,6 +49,19 @@ function _defineClass(...) -- @param protocol
         end
     cls.delete = function(self)
         end
+
+    local wcls = _weak(cls)
+    local meta = getmetatable(cls) or {}
+    if DEBUG then
+        meta.__newindex = DEBUG.preClassNewIndexFunc()
+    else
+        meta.__newindex = function(table,key,value) rawset(_getMemberTable(wcls()),key,value) end
+    end
+    meta.__index = function(table,key) return rawget(_getMemberTable(wcls()),key) end
+    if meta._memberTable == nil then
+        meta._memberTable = {}
+    end
+    setmetatable(cls, meta)
     return cls
 end
 ---------------------------------------
@@ -59,11 +83,28 @@ function _tableCopy(from, to)
     return to
 end
 function _addmetatable(table, add_meta)
-    local meta = getmetatable(table) or {}
+    local meta = _tableCopy(getmetatable(table) or {},{})
+    local mergeMetatable = function(key)
+        local meta_table = meta[key]
+        if meta_table == nil then
+            meta[key] = {}
+            meta_table = meta[key]
+        end
+        local add_metatable = add_meta[key] or {}
+        _tableCopy(meta_table, add_metatable)
+    end
+    mergeMetatable("_memberTable")
+    mergeMetatable("_mutableList")
+    mergeMetatable("_readableList")
+
     for k,v in pairs(add_meta) do
         meta[k] = v
     end
     setmetatable(table, meta)
+end
+function _getMemberTable(obj)
+    local meta = getmetatable(obj) or {}
+    return meta._memberTable
 end
 ---------------------------------------
 --- DEBUG function
@@ -91,7 +132,7 @@ function DEBUG.makeClassStatic(cls)
     local meta = getmetatable(cls) or {}
     meta.__newindex = DEBUG.checkSubstitutionFunc()
     meta.__index = function(table,key)
-        local value = rawget(table,key)
+        local value = rawget(_getMemberTable(table),key)
         if not DEBUG.isReadable(table,key) and value == nil then
             error("class member: '" .. key .. "' is not defined. in call of class member.")
         end
@@ -99,21 +140,21 @@ function DEBUG.makeClassStatic(cls)
     end
     setmetatable(cls, meta)
 end
+function DEBUG.checkSubstitution(table,key,value)
+    if not DEBUG.isReadable(table, key) then
+        error("class member: '" .. key .. "' is not defined. in substitution of class member.")
+    end
+    if not DEBUG.isMutable(table, key) then
+        error("class member: '" .. key .. "' is not _mutable. in substitution of class member.")
+    end
+    if not DEBUG.isKindOf(table[key], value) then
+        error("class member: '" .. key .. "' is not compatible. in substitution of class member.")
+    end
+end
 function DEBUG.checkSubstitutionFunc()
     return function(table,key,value)
-        if DEBUG.isReadable(table, key) then
-            if DEBUG.isMutable(table, key) then
-                if DEBUG.isKindOf(table[key], value) then
-                    rawset(table, key, value)
-                else
-                    error("class member: '" .. key .. "' is not compatible. in substitution of class member.")
-                end
-            else
-                error("class member: '" .. key .. "' is not _mutable. in substitution of class member.")
-            end
-        else
-            error("class member: '" .. key .. "' is not defined. in substitution of class member.")
-        end
+        DEBUG.checkSubstitution(table,key,value)
+        rawset(_getMemberTable(table), key, value)
     end
 end
 function DEBUG.isKindOf(base, value)
@@ -143,11 +184,11 @@ function DEBUG.mutableUnpack(obj)
     local meta = getmetatable(obj) or {}
     return meta._mutableValue
 end
-function DEBUG.setPreNewIndex(cls)
-    local meta = getmetatable(cls) or {}
-    meta.__newindex = function(table,key,value)
+function DEBUG.preClassNewIndexFunc()
+    return function(table,key,value)
+        local meta = getmetatable(table) or {}
         local unpack = DEBUG.mutableUnpack(value)
-        if unpack then
+        if unpack ~= nil then
             if meta._mutableList == nil then
                 meta._mutableList = {}
             end
@@ -174,9 +215,8 @@ function DEBUG.setPreNewIndex(cls)
             end
             value = newfunc
         end
-        rawset(table, key, value)
+        rawset(_getMemberTable(table), key, value)
     end
-    setmetatable(cls, meta)
 end
 function DEBUG.interfaceMap(any)
     local type = type(any)
@@ -204,6 +244,10 @@ function DEBUG.interfaceMap(any)
             for k,v in pairs(getmetatable(ins) or {}) do
                 if k == "_super" then
                     super = v
+                elseif k == "_memberTable" then
+                    for k2,v2 in pairs(v) do
+                        interface[k2] = true
+                    end
                 elseif k ~= "_mutableList" and k ~= "_readableList" and k ~= "__newindex" then
                     metainterface[k] = true
                 end

--- a/Assets/cytanb-utility-scripts/lua/kagerou_foundation_test.lua
+++ b/Assets/cytanb-utility-scripts/lua/kagerou_foundation_test.lua
@@ -52,6 +52,7 @@ _makeClassStatic(TutorialClass) -- _makeClassStatic() でクラス作成終了
     --- _weak
     --- _tableCopy
     --- _addmetatable
+    --- _getMemberTable
     --- DEBUG
 --- クラス内
     --- _rawnew
@@ -61,6 +62,7 @@ _makeClassStatic(TutorialClass) -- _makeClassStatic() でクラス作成終了
     --- _super
     --- _mutableList
     --- _readableList
+    --- _memberTable
 
 TutorialsugoiProtocol = _defineClass() -- _defineClass() でクラス作成開始
 function TutorialsugoiProtocol:sugoiInterface(text)
@@ -76,6 +78,7 @@ _makeClassStatic(TutorialfutuuProtocol) -- _makeClassStatic() でクラス作成
 
 --- ### 継承、多重継承 ###
 MultipleInheritance = _defineClass(TutorialsugoiProtocol, TutorialfutuuProtocol) -- _makeClassStatic() の引数に継承するクラスを並べると継承する
+MultipleInheritance.value = 5
 _makeClassStatic(MultipleInheritance)
 
 MyClass = _defineClass()
@@ -95,13 +98,19 @@ local instanceMyclass = MyClass:new() -- new で生成する
 assert(instanceMyclass.interface.xxx == 1) -- 未定義のインスタンスメンバはクラスのメンバ変数の定義が参照される
 
 instanceMyclass.interface = {xxx = 2}
-instanceMyclass.interface = {yyy = 2} -- これはインターフェイスに互換性がないのでエラーになる。 xxxが必要
+-- instanceMyclass.interface = {yyy = 2} -- これはインターフェイスに互換性がないのでエラーになる。 xxxが必要
 instanceMyclass.interface = {yyy = 2, xxx = 3} -- これはインターフェイスが互換性があるのでOK!
+
+assert(instanceMyclass.interface.xxx == 3)
+
 
 
 local testInterface = MultipleInheritance:new()
 instanceMyclass.interfacesugoi = testInterface -- これはインターフェイスが互換性があるのでOK!
 instanceMyclass.interfacefutuu = testInterface -- これはインターフェイスが互換性があるのでOK!
+assert(instanceMyclass.interfacefutuu.value == 5)
+-- instanceMyclass.interfacefutuu = nil -- これはインターフェイスが互換性がないのでだめ!
+
 
 --- ！メンバ関数定義と呼び出しには必ず :(セミコロン)を使うこと！エラーが発生します！
 -- instanceMyclass.new() -- これはエラーになる

--- a/Assets/cytanb-utility-scripts/lua/kagerou_utility.lua
+++ b/Assets/cytanb-utility-scripts/lua/kagerou_utility.lua
@@ -3,7 +3,7 @@
 --  MIT Licensed
 ----------------------------------------------------------------
 
-package.path=package.path..';./?.lua' 
+package.path=package.path..';./?.lua'
 require("kagerou_foundation")
 
 ---------------------------------------
@@ -29,21 +29,21 @@ function KFList:push_back(content)
 end
 function KFList:erase(KFList_n)
     if (self.first == KFList_n) then
-        self.first = KFList_n.next;
+        self._.first = KFList_n.next;
     else
-        KFList_n.prev().next = KFList_n.next
+        KFList_n.prev()._.next = KFList_n.next
     end
     if (self.last == KFList_n) then
         if KFList_n.prev then
-            self.last = KFList_n.prev()
+            self._.last = KFList_n.prev()
         else
-            self.last = nil
+            self._.last = nil
         end
     else
-        KFList_n.next.prev = KFList_n.prev
+        KFList_n.next._.prev = KFList_n.prev
     end
     KFList_n:delete()
-    self.size = self.size -1;
+    self._.size = self.size -1;
 end
 function KFList:delete()
     local KFList_n = self.first


### PR DESCRIPTION
# 修正点
## クラスモジュールのバグを修正
###概要
代入時型チェックが最初に代入される時しか動作しない問題を修正
###原因
代入時型チェックは"__newindex"メタメソッドを使用しているが、代入時に毎回呼ばれることを想定していたが、実際はtableに要素がないときだけ呼ばれる仕様なので、要素を代入する初めの一度だけ機能し、二回目からは型チェックが機能していなかった
###修正
tableに直接メンバを保存するのではなく、メタメソッドの"_membertable"に保存するように変更